### PR TITLE
Disable -etm MACs and chacha20-poly1305 ciphers [Terrapin CVE-2023-48795]

### DIFF
--- a/sshd_config.jinja
+++ b/sshd_config.jinja
@@ -34,5 +34,14 @@ KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org
 {# sntrup761x25519-sha512 is supported from openssh-8.5 (Ubuntu Jammy 22.04) onwards #}
 KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org
 {%- endif %}
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
-Ciphers chacha20-poly1305@openssh.com
+
+# Do not use -etm MACs for now, as they are vulnerable to Terrapin
+# See: https://terrapin-attack.com
+# MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+#MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+MACs hmac-sha2-512,hmac-sha2-256
+
+# Do not use chacha20-poly1305 for now, as it is vulnerable to Terrapin
+# See: https://terrapin-attack.com
+#Ciphers chacha20-poly1305@openssh.com
+Ciphers aes256-gcm@openssh.com

--- a/tests/integration/sshd/sshd_spec.rb
+++ b/tests/integration/sshd/sshd_spec.rb
@@ -11,8 +11,8 @@ control 'ssh' do
     its('content') { should match /^\s*PermitRootLogin no$/ }
     its('content') { should match /^\s*MaxStartups 10$/ }
     its('content') { should match /^\s*KexAlgorithms.*curve25519-sha256@libssh.org/ } # Match bionic and jammy versions
-    its('content') { should match /^\s*MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com$/ }
-    its('content') { should match /^\s*Ciphers chacha20-poly1305@openssh.com$/ }
+    its('content') { should match /^\s*MACs hmac-sha2-512,hmac-sha2-256$/ }
+    its('content') { should match /^\s*Ciphers aes256-gcm@openssh.com$/ }
     its('content') { should match /^\s*ClientAliveInterval 15$/ }
   end
 


### PR DESCRIPTION
The mentioned MACs/ ciphers are vulnerable to Terrapin. Use AES-GCM and hmac-sha2 as alternatives.

See: https://terrapin-attack.com